### PR TITLE
Keep track of the last fragment or sub-slide displayed when moving back or forward

### DIFF
--- a/atest/resources/Deck.resource
+++ b/atest/resources/Deck.resource
@@ -112,7 +112,7 @@ Filter Visible Elements
     RETURN    ${visible}
     [Teardown]    Resume Screenshots
 
-Advance Notebook Deck With Keyboard
+Advance Notebook Deck With Space
     [Documentation]    Go to the down/forward slide with space, wait a bit, then screenshot.
     [Arguments]    ${screenshot}=${EMPTY}    ${expect}=${EMPTY}    ${backup}=${FALSE}
     ${index} =    Get Active Cell Index
@@ -130,18 +130,47 @@ Advance Notebook Deck With Keyboard
     IF    ${screenshot.__len__()}    Capture Page Screenshot    ${screenshot}
     [Teardown]    Resume Screenshots
 
+Back Or Forward Notebook Deck With Arrows
+    [Documentation]    Go to the back/forward slide with arrows, wait a bit, then screenshot.
+    [Arguments]    ${screenshot}=${EMPTY}    ${expect}=${EMPTY}    ${backup}=${FALSE}
+    ${index} =    Get Active Cell Index
+    Send Error Screenshots To Trash
+    IF    ${backup}
+        Press Keys    css:body    ARROW_LEFT
+    ELSE
+        Press Keys    css:body    ARROW_RIGHT
+    END
+    Wait Until Cell Is Not Active    ${index}    1s
+    IF    ${expect.__len__()}
+        Wait Until Element Contains    css:${JLAB CSS ACTIVE CELL}    ${expect}
+    END
+    Resume Screenshots
+    IF    ${screenshot.__len__()}    Capture Page Screenshot    ${screenshot}
+    [Teardown]    Resume Screenshots
+
 Back Up Deck With Keyboard
     [Documentation]    Go to the up/back slide with space, wait a bit, then screenshot.
     [Arguments]    ${screenshot}=${EMPTY}    ${expect}=${EMPTY}
-    Advance Notebook Deck With Keyboard    ${screenshot}    ${expect}    backup=${TRUE}
+    Advance Notebook Deck With Space    ${screenshot}    ${expect}    backup=${TRUE}
 
-Really Advance Notebook Deck With Keyboard
+Really Advance Notebook Deck With Space
     [Documentation]    REALLY go to the down/forward slide with space, wait a bit, then screenshot.
     [Arguments]    ${screenshot}=${EMPTY}    ${expect}=${EMPTY}    ${backup}=${FALSE}
     Wait Until Keyword Succeeds    5x    0.5s
-    ...    Advance Notebook Deck With Keyboard    ${screenshot}    ${expect}    ${backup}
+    ...    Advance Notebook Deck With Space    ${screenshot}    ${expect}    ${backup}
 
-Really Back Up Deck With Keyboard
+Really Back Up Deck With Space
     [Documentation]    REALLY go to the up/back slide with space, wait a bit, then screenshot.
     [Arguments]    ${screenshot}=${EMPTY}    ${expect}=${EMPTY}
-    Really Advance Notebook Deck With Keyboard    ${screenshot}    ${expect}    backup=${TRUE}
+    Really Advance Notebook Deck With Space    ${screenshot}    ${expect}    backup=${TRUE}
+
+Really Move Forward Deck With Arrow
+    [Documentation]    REALLY go to back or forward slide with arrow, wait a bit, then screenshot.
+    [Arguments]    ${screenshot}=${EMPTY}    ${expect}=${EMPTY}    ${backup}=${FALSE}
+    Wait Until Keyword Succeeds    5x    0.5s
+    ...    Back Or Forward Notebook Deck With Arrows    ${screenshot}    ${expect}    ${backup}
+
+Really Move Back Deck With Arrow
+    [Documentation]    REALLY go to back slide with arrow, wait a bit, then screenshot.
+    [Arguments]    ${screenshot}=${EMPTY}    ${expect}=${EMPTY}
+    Really Move Forward Deck With Arrow    ${screenshot}    ${expect}    backup=${TRUE}

--- a/atest/resources/Docs.resource
+++ b/atest/resources/Docs.resource
@@ -31,6 +31,16 @@ Start Notebook Deck With Anchors
     Make Markdown Cell    back to [Hello World](#Hello-World)    Hello World
     Select A Slide Type    4    subslide    s1-01-new-slide.png
 
+Start Advanced Notebook Deck
+    [Documentation]    Make a few cells with fragments and subslides
+    Execute JupyterLab Command    Close All Tabs
+    Start Empty Notebook Deck
+    Click Element    css:${JLAB CSS ACTIVE CELL}
+    Make Markdown Cell    \# Slide 1    Slide 1    new=${FALSE}    screenshot=s2-00-slide1.png
+    Make Markdown Cell    - Fragment 1.1    Fragment 1.1    screenshot=s2-01-fragment1.png
+    Make Markdown Cell    \# Slide 2    Slide 2    screenshot=s2-02-slide2.png
+    Make Markdown Cell    - Fragment 2.1    Fragment 2.1    screenshot=s2-03-fragment2.png
+
 Tear Down Interactive Suite
     [Documentation]    Clean up after this suite.
     Execute JupyterLab Command    Close All Tabs

--- a/atest/suites/lab/02-navigate.robot
+++ b/atest/suites/lab/02-navigate.robot
@@ -22,10 +22,10 @@ Build and Navigate a Notebook Slide With Keyboard
     [Documentation]    Build and navigate a basic slide.
     Set Attempt Screenshot Directory    lab${/}navigate${/}keyboard
     Start Basic Notebook Deck
-    Really Back Up Deck With Keyboard    s0-03-backup.png    item1234
-    Really Back Up Deck With Keyboard    s0-04-backup.png    World
-    Really Advance Notebook Deck With Keyboard    s0-05-advance.png    item1234
-    Really Advance Notebook Deck With Keyboard    s0-06-advance.png    item4567
+    Really Back Up Deck With Space    s0-03-backup.png    item1234
+    Really Back Up Deck With Space    s0-04-backup.png    World
+    Really Advance Notebook Deck With Space    s0-05-advance.png    item1234
+    Really Advance Notebook Deck With Space    s0-06-advance.png    item4567
 
 Build and Navigate a Notebook Slide With Anchors
     [Documentation]    Build and navigate a basic slide.
@@ -34,3 +34,12 @@ Build and Navigate a Notebook Slide With Anchors
     Click Element    css:${CSS_DECK_VISIBLE} a[href^\="#Hello-World"]
     Wait Until Element Is Visible    css:${CSS_DECK_VISIBLE} h1
     Capture Page Screenshot    s1-02-back.png
+
+Build and Navigate an Advanced Notebook Deck With Arrows
+    [Documentation]    Build and navigate a basic slide.
+    Set Attempt Screenshot Directory    lab${/}navigate${/}arrows
+    Start Advanced Notebook Deck
+    Really Move Back Deck With Arrow    s2-04-back.png    Slide 1
+    Really Advance Notebook Deck With Space    s2-05-advance.png    Fragment 1
+    Really Move Forward Deck With Arrow    s2-06-advance.png    Fragment 2
+    Really Move Back Deck With Arrow    s2-07-back.png    Fragment 1

--- a/js/jupyterlab-deck/src/notebook/presenter.ts
+++ b/js/jupyterlab-deck/src/notebook/presenter.ts
@@ -384,13 +384,13 @@ export class NotebookPresenter implements IPresenter<NotebookPanel> {
     if (fromExtent != null) {
       let moveTo = fromExtent;
       if (['back', 'forward'].includes(direction)) {
-        moveTo = this._slideBackup(extents, activeCellIndex, fromExtent)
+        moveTo = this._slideBackup(extents, activeCellIndex, fromExtent);
       }
       panel.content.activeCellIndex = moveTo;
     } else if (fromExtentAlternate != null) {
       let moveTo = fromExtentAlternate;
       if (['back', 'forward'].includes(direction)) {
-        moveTo = this._slideBackup(extents, activeCellIndex, fromExtentAlternate)
+        moveTo = this._slideBackup(extents, activeCellIndex, fromExtentAlternate);
       }
       panel.content.activeCellIndex = moveTo;
     } else {
@@ -922,9 +922,9 @@ export class NotebookPresenter implements IPresenter<NotebookPanel> {
    * set up.
    */
   protected _slideBackup(
-    extents:NotebookPresenter.TExtentMap,
+    extents: NotebookPresenter.TExtentMap,
     current: number,
-    target: number
+    target: number,
   ) {
     // Set parent slide redirection
     let parentSlide = extents.get(current);
@@ -939,8 +939,7 @@ export class NotebookPresenter implements IPresenter<NotebookPanel> {
     // or if the current is a slide.
     if (parentSlide?.index === current || parentSlide?.index === target) {
       parentSlide.redirect = null;
-    }
-    else if (parentSlide?.slideType === 'slide') {
+    } else if (parentSlide?.slideType === 'slide') {
       parentSlide.redirect = current;
     }
 


### PR DESCRIPTION

## Checklist

- [x] ran `doit lint` locally

## References

Fixes https://github.com/deathbeds/jupyterlab-deck/issues/49

## Code changes

Adds a `redirect` attribute to slide extent.
This new attribute is filled with the index of the last fragment or subslide displayed in this "slide group".
It is used when falling back on a slide with left/right arrows.

## User-facing changes

Using left/right arrows does not necessarily fall back on a `Slide` type anymore, but on the latest *fragment* of that *slide*.

## Backwards-incompatible changes

None